### PR TITLE
README: Bump version to 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add it to your ``Cargo.toml``:
 
 ```toml
 [dependencies]
-lddtree = "0.2"
+lddtree = "0.3"
 ```
 
 ## Command line utility


### PR DESCRIPTION
The README example of a Cargo.toml should say 0.3 now, not 0.2.