### PR TITLE
Upgrade goblin to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
 dependencies = [
  "log",
  "plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/messense/lddtree-rs"
 [dependencies]
 fs-err = "2.6.0"
 glob = "0.3.0"
-goblin = "0.8.0"
+goblin = "0.9.0"


### PR DESCRIPTION
The breaking change from 0.8.0 appears to be the addition of a value to a pub enum associated with TE (terse executable) support; this does not look like it should affect lddtree-rs’s usage of goblin since it doesn’t match exhaustively on this enum.

Furthermore, `cargo test` passes.

https://github.com/m4b/goblin/blob/d096260201158ed34d64728fd1ab0ca125e2f956/CHANGELOG.md#092----2024-10-26